### PR TITLE
Updated redirect link in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,7 +103,7 @@
   to = "/docs/developer/tutorial/ios/"
 
 [[redirects]]
-from = "/docs/developer/api/"
+from = "/docs/developer/api/*"
 to = "/docs/developer/#api"
 
 [[redirects]]


### PR DESCRIPTION
Updated redirect link in netlfiy.toml

```
from = "/docs/developer/api/*"
to = "/docs/developer/#api"

```